### PR TITLE
Fix port definition in blink module

### DIFF
--- a/src/blinky.v
+++ b/src/blinky.v
@@ -1,6 +1,6 @@
 module blink (
     input wire clock,
-    output reg led IO_voltage
+    output reg IO_voltage
 );
 /********** Counter **********/
 //parameter Clock_frequency = 27_000_000; // Crystal oscillator frequency is 27Mhz


### PR DESCRIPTION
## Summary
- correct output port declaration in `src/blinky.v`

## Testing
- `iverilog -o testbench.vvp src/testbench.v src/blinky.v src/counter.v src/adder.v src/dtrigger.v src/lab00_test.v src/led.v` *(fails: command not found)*